### PR TITLE
communication between the browser window and the extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,5 +14,8 @@
       "run_at": "document_start",
       "js": ["./build/contentScript.js"]
     }
-  ]
+  ],
+  "background": {
+    "scripts": ["./build/backgroundScript.js"]
+  }
 }

--- a/src/background_script.js
+++ b/src/background_script.js
@@ -1,0 +1,21 @@
+import browser from "webextension-polyfill";
+
+let portsToPanel = [];
+
+browser.runtime.onMessage.addListener((msg, sender) => {
+  //message received from the content-script running in the page context
+  portsToPanel.forEach(port => {
+    if (sender.id === port.sender.id) {
+      port.postMessage(msg);
+    }
+  });
+});
+
+browser.runtime.onConnect.addListener(port => {
+  if (port.name !== "panel-devtools") return;
+  portsToPanel = [...portsToPanel, port];
+
+  port.onDisconnect.addListener(() => {
+    portsToPanel = portsToPanel.filter(p => p !== port);
+  });
+});

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -1,6 +1,14 @@
 import { installDevtools } from "./install-devtools";
+import browser from "webextension-polyfill";
 
 var script = document.createElement("script");
 script.textContent = `(${installDevtools.toString()})()`;
 (document.head || document.documentElement).appendChild(script);
 script.remove();
+
+window.addEventListener("single-spa:app-change", () => {
+  browser.runtime.sendMessage({
+    from: "single-spa",
+    type: "app-change"
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   mode: "development",
   entry: {
     contentScript: "./src/content_script.js",
+    backgroundScript: "./src/background_script.js",
     panel: "./src/panel.js",
     panelApp: "./src/panel-app.js"
   },


### PR DESCRIPTION
setup the content script to listen to the app change event from single-spa and send an event to the background script

setup a background script that listens to messages from the content script, and forwards that onto the panel

setup the panel.js script to listen to scripts from the background script, and send it as a custom event to the panel's window

setup the panel app to listen to the custom events from panel.js and get the appData again when it happens, then rerender.

simple!