### PR TITLE
Cleanup and chrome support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,13 +2,9 @@
   "manifest_version": 2,
   "name": "single-spa Inspector",
   "short_name": "sspa Inspect",
-  "version": "0.1.1a6",
+  "version": "0.1.2",
   "author": "Anthony Frehner",
   "homepage_url": "https://github.com/CanopyTax/single-spa-inspector",
-  "developer": {
-    "name": "Anthony Frehner",
-    "url": "https://github.com/CanopyTax/single-spa-inspector"
-  },
   "description": "A devtools panel for single-spa applications",
   "browser_action": {
     "default_icon": "./logo-white-bgblue.svg",

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -6,9 +6,9 @@ script.textContent = `(${installDevtools.toString()})()`;
 (document.head || document.documentElement).appendChild(script);
 script.remove();
 
-window.addEventListener("single-spa:app-change", () => {
+window.addEventListener("single-spa:routing-event", () => {
   browser.runtime.sendMessage({
     from: "single-spa",
-    type: "app-change"
+    type: "routing-event"
   });
 });

--- a/src/inspected-window.helper.js
+++ b/src/inspected-window.helper.js
@@ -5,10 +5,17 @@ export async function evalDevtoolsCmd(evalString) {
   const result = await browser.devtools.inspectedWindow.eval(
     `window.__SINGLE_SPA_DEVTOOLS__.${evalString}`
   );
-  if (result[1] && result[1].isError) {
+  if (result[1] && (result[1].isError || result[1].isException)) {
     throw new Error(
       `evalDevtoolsCmd '${evalString}' failed: ${JSON.stringify(result[1])}`
     );
   }
-  return result[0];
+
+  if (typeof InstallTrigger !== "undefined") {
+    // use this hack until this commit https://github.com/mozilla/webextension-polyfill/commit/6f178c56daed2f548d29e879e3caf082183eed3a is released
+    // see https://github.com/mozilla/webextension-polyfill/issues/168 and https://github.com/mozilla/webextension-polyfill/pull/175 and https://stackoverflow.com/a/41820692/2098017
+    return result[0];
+  } else {
+    return result;
+  }
 }

--- a/src/panel-app/app-status-override.component.js
+++ b/src/panel-app/app-status-override.component.js
@@ -19,10 +19,10 @@ export default function AppStatusOverride(props) {
   return (
     <>
       {(activeWhenForced === "off" || props.app.status !== "MOUNTED") && (
-        <button onClick={() => dispatch({ type: "on" })}>Force Mount</button>
+        <button onClick={() => dispatch({ type: "on" })}>Mount</button>
       )}
       {(activeWhenForced === "on" || props.app.status === "MOUNTED") && (
-        <button onClick={() => dispatch({ type: "off" })}>Force Unmount</button>
+        <button onClick={() => dispatch({ type: "off" })}>Unmount</button>
       )}
       <button
         onClick={() => dispatch({ type: "reset" })}

--- a/src/panel.js
+++ b/src/panel.js
@@ -11,7 +11,7 @@ async function createPanel() {
   const panel = await browser.devtools.panels.create(
     "single-spa Inspector",
     "/logo-white-bgblue.svg",
-    "./panel.html"
+    "/build/panel.html"
   );
 
   panel.onShown.addListener(panelWindow => {


### PR DESCRIPTION
Removed developer from manifest because that breaks chrome

Changed the event we're listening to to be "routing-event" since that event is fired every time reroute() is called -- this fixed a bug with the "reset" button for force mounting/unmounting where if the override returned the same boolean as the original mount function, then "app-change" event wasn't fired and the devtools would be in an inconsistent state.

Added a hack for determining if you're in firefox or chrome, and changing the return value based upon that.

Made sure to clean up after myself in adding and removing event listeners in the devtools window.

Fixed a bug where the built extension wasn't working but dev extension was, since "./panel.html" should have be referring to the one in the build folder.