### PR TITLE
Feature fix table styles

### DIFF
--- a/src/panel-app/apps.component.js
+++ b/src/panel-app/apps.component.js
@@ -104,7 +104,6 @@ function deOverlayApp(app) {
 const css = `
 & .table {
   width: 100%;
-  height: 100%;
 }
 
 & .table td, .table th {

--- a/src/panel-app/apps.component.js
+++ b/src/panel-app/apps.component.js
@@ -27,7 +27,7 @@ export default function Apps(props) {
       <table className={"table"}>
         <thead className="table-header">
           <tr>
-            <th>Name</th>
+            <th>App Name</th>
             <th>Status</th>
             <th>Status Overrides</th>
           </tr>

--- a/src/panel-app/apps.component.js
+++ b/src/panel-app/apps.component.js
@@ -15,9 +15,16 @@ export default function Apps(props) {
     }
   }, [hovered]);
 
+  useEffect(() => {
+    document.body.classList.add(props.theme);
+    return () => {
+      document.body.classList.remove(props.theme);
+    };
+  }, [props.theme]);
+
   return (
     <Scoped css={css}>
-      <table className={`theme-${props.theme ? props.theme : "dark"} table`}>
+      <table className={"table"}>
         <thead className="table-header">
           <tr>
             <th>Name</th>
@@ -102,6 +109,15 @@ function deOverlayApp(app) {
 }
 
 const css = `
+body {
+  font-family: sans-serif;
+}
+
+body.dark {
+  background-color: #272822;
+  color: #F8F8F2;
+}
+
 & .table {
   width: 100%;
 }
@@ -113,11 +129,6 @@ const css = `
 & .table-header {
   color: #66D9EF;
   text-align: left;
-}
-
-& .theme-dark {
-  background-color: #272822;
-  color: #F8F8F2;
 }
 
 & .app-status {


### PR DESCRIPTION
Resolves #11 

I fixed this by removing the height from the table, and moving the theme color to be applied to the document.body instead. While I was at it, I changed the font to sans-serif to match the rest of devtools UI, and updated "Name" to "App Name" to match what's used in the docs.

Screenshot of what it looks like now:

**Light theme**

<img width="1062" alt="screen shot 2019-02-24 at 11 36 44 pm" src="https://user-images.githubusercontent.com/4202993/53318658-35764b80-388d-11e9-9b96-499cb3ce6154.png">

**Dark theme**

<img width="1061" alt="screen shot 2019-02-24 at 11 37 14 pm" src="https://user-images.githubusercontent.com/4202993/53318662-39a26900-388d-11e9-8b96-2a7c66d30359.png">

One last thing, I noticed that when changing themes in FF Devtools, the app doesn't receive any prop changes about the themeName. Probably not a big deal, but wanted to mention it for the future.