### PR TITLE
Fix: CSS escape app names in default container id

### DIFF
--- a/src/inspected-window-helpers/overlay-helpers.js
+++ b/src/inspected-window-helpers/overlay-helpers.js
@@ -33,9 +33,11 @@ export function setupOverlayHelpers() {
 
   function getOverlayNodesAndOptions(app) {
     const { selectors = [], options = {} } = app.devtools.overlays;
+    const singleSpaDefaultContainerId =
+      "#" + CSS.escape(`single-spa-application:${app.name}`);
     return {
       nodes: selectors
-        .concat(`#single-spa-application\\:${app.name}`)
+        .concat(singleSpaDefaultContainerId)
         .map(selector => document.querySelector(selector))
         .filter(node => node),
       options


### PR DESCRIPTION
Resolves #24 

CSS escape the single-spa default container id, which includes the app name, that may have special characters.