### PR TITLE
Fix toggle-group alignment

### DIFF
--- a/src/panel-app/toggle-group.js
+++ b/src/panel-app/toggle-group.js
@@ -8,24 +8,25 @@ export default function ToggleGroup(props) {
 
   return (
     <fieldset {...styles} {...rest}>
-      {React.Children.map(children, child => {
-        return child.type === ToggleOption
-          ? React.cloneElement(child, {
-              onChange,
-              name,
-              checked: child.props.value === value
-            })
-          : child;
-      })}
+      {/* div to fix Chrome not rendering fieldsets as flex containers */}
+      <div>
+        {React.Children.map(children, child => {
+          return child.type === ToggleOption
+            ? React.cloneElement(child, {
+                onChange,
+                name,
+                checked: child.props.value === value
+              })
+            : child;
+        })}
+      </div>
     </fieldset>
   );
 }
 
 const css = `
 & fieldset {
-  align-items: center;
   border: none;
-  display: flex;
   margin: 0;
   padding: var(--table-spacing);
 }


### PR DESCRIPTION
Resolves #31 

This happens due to a possible bug in Chrome that doesn't allow applying flex to a fieldset (see https://stackoverflow.com/a/28078942/2554793). Wrapping in a div fixes it.